### PR TITLE
Add factions

### DIFF
--- a/NPC Replacer Follower Converter.pas
+++ b/NPC Replacer Follower Converter.pas
@@ -93,24 +93,27 @@ begin
 
   // Faction の修正
   if ENABLE_SET_FACTIONS then begin
+    // Factionsエレメントが存在していた場合、削除してFactionsエレメントをクリアにする
     factions := ElementByPath(e, 'Factions');
     if Assigned(factions) then
       RemoveElement(e, 'Factions');
-   
+    
+    // Factionsエレメントを新規追加、自動で追加されたnull Factionを削除
     factions := Add(e, 'Factions', True);
     RemoveElement(factions, ElementByIndex(factions, 0));
     
+    // PotentialMarriageFactionを追加
     newFaction := ElementAssign(factions, HighInteger, nil, False);
     SetElementEditValues(newFaction, 'Faction', IntToHex(GetLoadOrderFormID(potMarriageFac), 8));
     
+    // PotentialFollowerFactionを追加
     newFaction := ElementAssign(factions, HighInteger, nil, False);
     SetElementEditValues(newFaction, 'Faction', IntToHex(GetLoadOrderFormID(potFollowerFac), 8));
     
+    // CurrentFollowerFactionを追加、ランクを-1に設定
     newFaction := ElementAssign(factions, HighInteger, nil, False);
     SetElementEditValues(newFaction, 'Faction', IntToHex(GetLoadOrderFormID(curFollowerFac), 8));
     SetElementEditValues(newFaction, 'Rank', '-1');
-    
-
   end;
 
 {
@@ -170,7 +173,9 @@ begin
     AddMessage('Added a Relationship record: ' + Name(e) + ' -> Player');
   end;
 
-  
+  if ENABLE_SET_HOME_LOCATION then begin
+    
+  end;
   Result := 0;
 end;
 

--- a/NPC Replacer Follower Converter.pas
+++ b/NPC Replacer Follower Converter.pas
@@ -68,14 +68,16 @@ var
   vmad, factions, newFaction, aiPackages, voice, outfit, flags, refRel, rel: IInterface;
   recordGroup: IwbGroupRecord;
   existRelRec: IwbMainRecord;
-  relEditorID: string;
+  NPCEditorID, baseEditorID, relEditorID: string;
+  underscorePos: integer;
 begin
   // NPCレコードのみ処理
   if Signature(e) <> 'NPC_' then Exit;
 
   AddMessage('Modifying NPC: ' + Name(e));
 
-
+  NPCEditorID := GetElementEditValues(e, 'EDID');
+  
   // クエストスクリプトの削除
   if ENABLE_SET_VMADS then begin
     vmad := ElementBySignature(e, 'VMAD');
@@ -143,7 +145,7 @@ begin
 
   // Relationshipレコードを追加
   // 選択中のNPCに関連するRelationshipレコードがすでに存在していたら何もしない
-  relEditorID := GetElementEditValues(e, 'EDID') + 'Rel';
+  relEditorID := NPCEditorID + 'Rel';
   recordGroup := GroupBySignature(GetFile(e), 'RELA');
   existRelRec := MainRecordByEditorID(recordGroup, relEditorID);
   if Assigned(existRelRec) then
@@ -173,9 +175,14 @@ begin
     AddMessage('Added a Relationship record: ' + Name(e) + ' -> Player');
   end;
 
+  // 配置する場所を設定
   if ENABLE_SET_HOME_LOCATION then begin
-    
+    // EditorIDから本来のリプレイス先となるNPCのEditorIDを取得
+    underscorePos := LastDelimiter('_', NPCEditorID);
+    AddMessage('UnderScore position: ' + IntToStr(underscorePos));
+    // リプレイス先NPCの配置場所を取得し、同じ場所に配置する
   end;
+  
   Result := 0;
 end;
 

--- a/NPC Replacer Follower Converter.pas
+++ b/NPC Replacer Follower Converter.pas
@@ -65,7 +65,9 @@ end;
 
 function Process(e: IInterface): integer;
 var
-  vmad, factions, newFaction, aiPackages, voice, outfit, flags, existRel, refRel, rel: IInterface;
+  vmad, factions, newFaction, aiPackages, voice, outfit, flags, refRel, rel: IInterface;
+  recordGroup: IwbGroupRecord;
+  existRelRec: IwbMainRecord;
   relEditorID: string;
 begin
   // NPCレコードのみ処理
@@ -96,6 +98,7 @@ begin
       RemoveElement(e, 'Factions');
    
     factions := Add(e, 'Factions', True);
+    RemoveElement(factions, ElementByIndex(factions, 0));
     
     newFaction := ElementAssign(factions, HighInteger, nil, False);
     SetElementEditValues(newFaction, 'Faction', IntToHex(GetLoadOrderFormID(potMarriageFac), 8));
@@ -107,7 +110,7 @@ begin
     SetElementEditValues(newFaction, 'Faction', IntToHex(GetLoadOrderFormID(curFollowerFac), 8));
     SetElementEditValues(newFaction, 'Rank', '-1');
     
-    RemoveElement(factions, ElementByIndex(factions, 0));
+
   end;
 
 {
@@ -136,10 +139,12 @@ begin
 
 
   // Relationshipレコードを追加
+  // 選択中のNPCに関連するRelationshipレコードがすでに存在していたら何もしない
   relEditorID := GetElementEditValues(e, 'EDID') + 'Rel';
-  existRel := RecordByEditorID(GetFile(e), relEditorID);
-  if Assigned(existRel) then
-      AddMessage('A Relationship record for this NPC already exists.');
+  recordGroup := GroupBySignature(GetFile(e), 'RELA');
+  existRelRec := MainRecordByEditorID(recordGroup, relEditorID);
+  if Assigned(existRelRec) then
+      AddMessage('A Relationship record for this NPC already exists.')
   else begin
     // 普通にレコードを追加できないので、Skyrim.esm内のRelationshipレコードをコピーする
     // HousecarlWhiterunPlayerRelationshipをコピー元として参照する


### PR DESCRIPTION
元からあるファクションを削除して、フォロワー化に必要なファクションを追加
ついでに結婚可能にしておいた

その他いろいろ

- Relationshipレコードを追加する前に、すでに同じレコードが存在しているかチェックする処理を追加
- NPCを自動配置するの処理の準備として、本来のリプレイス先のEditor IDを取得する処理を追加